### PR TITLE
Update python_version for 3.13

### DIFF
--- a/phishlabs.json
+++ b/phishlabs.json
@@ -15,7 +15,7 @@
     "package_name": "phantom_phishlabs",
     "main_module": "phishlabs_connector.py",
     "min_phantom_version": "5.1.0",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": true,
     "latest_tested_versions": [
         "Cloud, October 8, 2021"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions-3.13`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions-3.13)