### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # PhishLabs
 
-Publisher: Splunk \
-Connector Version: 2.0.5 \
-Product Vendor: PhishLabs \
-Product Name: PhishLabs \
+Publisher: Splunk <br>
+Connector Version: 2.0.5 <br>
+Product Vendor: PhishLabs <br>
+Product Name: PhishLabs <br>
 Minimum Product Version: 5.1.0
 
 This app implements investigative actions on the PhishLabs Casetracker Portal
@@ -19,17 +19,17 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[get ticket](#action-get-ticket) - Get case (issue) information \
-[create ticket](#action-create-ticket) - Create a new case submission \
-[list tickets](#action-list-tickets) - Get a list of cases in PhishLabs \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[get ticket](#action-get-ticket) - Get case (issue) information <br>
+[create ticket](#action-create-ticket) - Create a new case submission <br>
+[list tickets](#action-list-tickets) - Get a list of cases in PhishLabs <br>
 [get config](#action-get-config) - Return the list of brands and case types currently configured in PhishLabs
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -44,7 +44,7 @@ No Output
 
 Get case (issue) information
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -104,7 +104,7 @@ action_result.data.\*.resolution | string | | This is a test case |
 
 Create a new case submission
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -144,7 +144,7 @@ action_result.data.\*.updatedCase.caseNumber | numeric | | 2648042 |
 
 Get a list of cases in PhishLabs
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -212,7 +212,7 @@ action_result.data.\*.caseLinks.\*.linkCreated | string | | 2021-10-11T13:48:55.
 
 Return the list of brands and case types currently configured in PhishLabs
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters

--- a/phishlabs.json
+++ b/phishlabs.json
@@ -1104,5 +1104,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/phishlabs.json
+++ b/phishlabs.json
@@ -15,7 +15,7 @@
     "package_name": "phantom_phishlabs",
     "main_module": "phishlabs_connector.py",
     "min_phantom_version": "5.1.0",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "latest_tested_versions": [
         "Cloud, October 8, 2021"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Update NOTICE file with updated dependencies
 * Apply pre-commit fixes
 * Remove beautifulsoup4 from requirements.txt
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)